### PR TITLE
Add modular league scrapers

### DIFF
--- a/Desktop/uball/server/api.js
+++ b/Desktop/uball/server/api.js
@@ -1,6 +1,13 @@
 import express from "express";
 import cors from "cors";
 import { scrapeAndStoreTransfers } from "./transfermarktScraper.js";
+import {
+  scrapePremierLeague,
+  scrapeLaLiga,
+  scrapeBundesliga,
+  scrapeSerieA,
+  scrapeLigue1,
+} from "./scrapers/index.js";
 import db from './db.js';
 const app = express();
 const PORT = 3001;
@@ -14,6 +21,35 @@ app.get('/api/transfers', (req, res) => {
     }
     res.json(rows);
   });
+});
+
+app.get('/api/league/:id', async (req, res) => {
+  try {
+    let data;
+    switch (req.params.id) {
+      case 'premier-league':
+        data = await scrapePremierLeague();
+        break;
+      case 'la-liga':
+        data = await scrapeLaLiga();
+        break;
+      case 'bundesliga':
+        data = await scrapeBundesliga();
+        break;
+      case 'serie-a':
+        data = await scrapeSerieA();
+        break;
+      case 'ligue-1':
+        data = await scrapeLigue1();
+        break;
+      default:
+        return res.status(404).json({ error: 'League not found' });
+    }
+    res.json(data);
+  } catch (err) {
+    console.error('Failed to scrape league:', err);
+    res.status(500).json({ error: 'Scrape failed' });
+  }
 });
 
 setInterval(() => {

--- a/Desktop/uball/server/scrapers/bundesliga.js
+++ b/Desktop/uball/server/scrapers/bundesliga.js
@@ -1,0 +1,3 @@
+import { parseWikiTable } from './utils.js';
+const URL = 'https://en.wikipedia.org/wiki/2023%E2%80%9324_Bundesliga';
+export const scrapeBundesliga = () => parseWikiTable(URL);

--- a/Desktop/uball/server/scrapers/index.js
+++ b/Desktop/uball/server/scrapers/index.js
@@ -1,0 +1,5 @@
+export { scrapePremierLeague } from './premierLeague.js';
+export { scrapeLaLiga } from './laLiga.js';
+export { scrapeBundesliga } from './bundesliga.js';
+export { scrapeSerieA } from './serieA.js';
+export { scrapeLigue1 } from './ligue1.js';

--- a/Desktop/uball/server/scrapers/laLiga.js
+++ b/Desktop/uball/server/scrapers/laLiga.js
@@ -1,0 +1,3 @@
+import { parseWikiTable } from './utils.js';
+const URL = 'https://en.wikipedia.org/wiki/2023%E2%80%9324_La_Liga';
+export const scrapeLaLiga = () => parseWikiTable(URL);

--- a/Desktop/uball/server/scrapers/ligue1.js
+++ b/Desktop/uball/server/scrapers/ligue1.js
@@ -1,0 +1,3 @@
+import { parseWikiTable } from './utils.js';
+const URL = 'https://en.wikipedia.org/wiki/2023%E2%80%9324_Ligue_1';
+export const scrapeLigue1 = () => parseWikiTable(URL);

--- a/Desktop/uball/server/scrapers/premierLeague.js
+++ b/Desktop/uball/server/scrapers/premierLeague.js
@@ -1,0 +1,3 @@
+import { parseWikiTable } from './utils.js';
+const URL = 'https://en.wikipedia.org/wiki/2023%E2%80%9324_Premier_League';
+export const scrapePremierLeague = () => parseWikiTable(URL);

--- a/Desktop/uball/server/scrapers/serieA.js
+++ b/Desktop/uball/server/scrapers/serieA.js
@@ -1,0 +1,3 @@
+import { parseWikiTable } from './utils.js';
+const URL = 'https://en.wikipedia.org/wiki/2023%E2%80%9324_Serie_A';
+export const scrapeSerieA = () => parseWikiTable(URL);

--- a/Desktop/uball/server/scrapers/utils.js
+++ b/Desktop/uball/server/scrapers/utils.js
@@ -1,0 +1,35 @@
+import fetch from 'node-fetch';
+import * as cheerio from 'cheerio';
+
+export async function parseWikiTable(url) {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'Mozilla/5.0' }
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  }
+  const html = await res.text();
+  const $ = cheerio.load(html);
+  const table = $("#League_table").parent().nextAll("table").first();
+  const rows = table.find("tbody tr");
+  const data = [];
+  rows.each((_, row) => {
+    const cells = $(row).find('th, td');
+    if (cells.length < 10) return;
+    const pos = parseInt($(cells[0]).text().trim(), 10);
+    if (isNaN(pos)) return;
+    data.push({
+      position: pos,
+      team: $(cells[1]).text().trim(),
+      played: parseInt($(cells[2]).text().trim(), 10),
+      won: parseInt($(cells[3]).text().trim(), 10),
+      drawn: parseInt($(cells[4]).text().trim(), 10),
+      lost: parseInt($(cells[5]).text().trim(), 10),
+      gf: parseInt($(cells[6]).text().trim(), 10),
+      ga: parseInt($(cells[7]).text().trim(), 10),
+      gd: parseInt($(cells[8]).text().trim(), 10),
+      pts: parseInt($(cells[9]).text().trim(), 10)
+    });
+  });
+  return data;
+}


### PR DESCRIPTION
## Summary
- add wiki table parser helpers
- add modular scrapers for each major league
- expose new `/api/league/:id` endpoint

## Testing
- `npm run lint` *(fails: Calendar, Users, TrendingUp etc. unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6872e50a2dd0832bb0b164cac7f5a5fe